### PR TITLE
Fix spdlog error with sed in GitHub actions

### DIFF
--- a/.github/workflows/linux-compile.yml
+++ b/.github/workflows/linux-compile.yml
@@ -20,6 +20,11 @@ jobs:
         run: sudo apt update
       - name: Install dependencies
         run: sudo apt-get install gcc g++ git cmake ninja-build lsb-release libsdl2-dev libpng-dev libsdl2-net-dev libzip-dev zipcmp zipmerge ziptool nlohmann-json3-dev libtinyxml2-dev libspdlog-dev libboost-dev libopengl-dev libogg-dev libvorbis-dev
+      - name: Patch spdlog (fmt 10 compatibility)
+        run: |
+          sudo sed -i 's/fmt::detail::vformat_to(buf, fmt, fmt::make_format_args(/fmt::detail::vformat_to(buf, fmt, fmt::make_format_args<fmt::format_context>(/' /usr/include/spdlog/logger.h || true
+          sudo sed -i 's/fmt::detail::vformat_to(wbuf, fmt, fmt::make_format_args(/fmt::detail::vformat_to(wbuf, fmt, fmt::make_format_args<fmt::wformat_context>(/' /usr/include/spdlog/logger.h || true
+          echo "spdlog patched for fmt 10 compatibility"
       - name: Install latest SDL
         run: |
           export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -138,6 +138,11 @@ jobs:
         run: sudo apt update
       - name: Install dependencies
         run: sudo apt-get install gcc g++ git cmake ninja-build lsb-release libsdl2-dev libsdl2-net-dev libpng-dev libsdl2-net-dev libzip-dev zipcmp zipmerge ziptool nlohmann-json3-dev libtinyxml2-dev libspdlog-dev libboost-dev libopengl-dev libogg-dev libvorbis-dev
+      - name: Patch spdlog (fmt 10 compatibility)
+        run: |
+          sudo sed -i 's/fmt::detail::vformat_to(buf, fmt, fmt::make_format_args(/fmt::detail::vformat_to(buf, fmt, fmt::make_format_args<fmt::format_context>(/' /usr/include/spdlog/logger.h || true
+          sudo sed -i 's/fmt::detail::vformat_to(wbuf, fmt, fmt::make_format_args(/fmt::detail::vformat_to(wbuf, fmt, fmt::make_format_args<fmt::wformat_context>(/' /usr/include/spdlog/logger.h || true
+          echo "spdlog patched for fmt 10 compatibility"
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1.2.14
         with:
@@ -223,6 +228,11 @@ jobs:
         run: sudo apt update
       - name: Install dependencies
         run: sudo apt-get install gcc g++ git cmake ninja-build lsb-release libsdl2-dev libsdl2-net-dev libpng-dev libsdl2-net-dev libzip-dev zipcmp zipmerge ziptool nlohmann-json3-dev libtinyxml2-dev libspdlog-dev libboost-dev libopengl-dev libogg-dev libvorbis-dev
+      - name: Patch spdlog (fmt 10 compatibility)
+        run: |
+          sudo sed -i 's/fmt::detail::vformat_to(buf, fmt, fmt::make_format_args(/fmt::detail::vformat_to(buf, fmt, fmt::make_format_args<fmt::format_context>(/' /usr/include/spdlog/logger.h || true
+          sudo sed -i 's/fmt::detail::vformat_to(wbuf, fmt, fmt::make_format_args(/fmt::detail::vformat_to(wbuf, fmt, fmt::make_format_args<fmt::wformat_context>(/' /usr/include/spdlog/logger.h || true
+          echo "spdlog patched for fmt 10 compatibility"
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1.2.14
         with:


### PR DESCRIPTION
Add a `sed` patch to GitHub Actions workflows to fix spdlog compilation errors with fmt-10.

The patch injects missing `<fmt::format_context>` / `<fmt::wformat_context>` template arguments into `/usr/include/spdlog/logger.h` to resolve "cannot bind non-const lvalue reference..." errors caused by fmt-10 / GCC-13 incompatibility.

---
<a href="https://cursor.com/background-agent?bcId=bc-37c3f313-adef-4b7d-98f3-798d4d55d076">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-37c3f313-adef-4b7d-98f3-798d4d55d076">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

