### PR TITLE
Fix spdlog error with sed in GitHub actions

### DIFF
--- a/.github/workflows/linux-compile.yml
+++ b/.github/workflows/linux-compile.yml
@@ -20,6 +20,11 @@ jobs:
         run: sudo apt update
       - name: Install dependencies
         run: sudo apt-get install gcc g++ git cmake ninja-build lsb-release libsdl2-dev libpng-dev libsdl2-net-dev libzip-dev zipcmp zipmerge ziptool nlohmann-json3-dev libtinyxml2-dev libspdlog-dev libboost-dev libopengl-dev libogg-dev libvorbis-dev
+      - name: Fix spdlog issue in torch
+        run: |
+          # Fix spdlog find_package issue in torch CMakeLists.txt
+          sed -i 's/find_package(spdlog REQUIRED)/find_package(spdlog QUIET)\n\tif(NOT spdlog_FOUND)\n\t\tFetchContent_Declare(\n\t\t\tspdlog\n\t\t\tGIT_REPOSITORY https:\/\/github.com\/gabime\/spdlog.git\n\t\t\tGIT_TAG 7e635fca68d014934b4af8a1cf874f63989352b7\n\t\t)\n\t\tFetchContent_MakeAvailable(spdlog)\n\t\tset(spdlog_FOUND TRUE)\n\tendif()/' torch/CMakeLists.txt
+          sed -i 's/target_link_libraries(${PROJECT_NAME} PUBLIC spdlog::spdlog)/if(spdlog_FOUND)\n\tif(TARGET spdlog::spdlog)\n\t\ttarget_link_libraries(${PROJECT_NAME} PUBLIC spdlog::spdlog)\n\telse()\n\t\ttarget_link_libraries(${PROJECT_NAME} PUBLIC spdlog)\n\tendif()\nendif()/' torch/CMakeLists.txt
       - name: Install latest SDL
         run: |
           export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -139,6 +139,11 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get install gcc g++ git cmake ninja-build lsb-release libsdl2-dev libsdl2-net-dev libpng-dev libsdl2-net-dev libzip-dev zipcmp zipmerge ziptool nlohmann-json3-dev libtinyxml2-dev libspdlog-dev libboost-dev libopengl-dev libogg-dev libvorbis-dev
+      - name: Fix spdlog issue in torch
+        run: |
+          # Fix spdlog find_package issue in torch CMakeLists.txt
+          sed -i 's/find_package(spdlog REQUIRED)/find_package(spdlog QUIET)\n\tif(NOT spdlog_FOUND)\n\t\tFetchContent_Declare(\n\t\t\tspdlog\n\t\t\tGIT_REPOSITORY https:\/\/github.com\/gabime\/spdlog.git\n\t\t\tGIT_TAG 7e635fca68d014934b4af8a1cf874f63989352b7\n\t\t)\n\t\tFetchContent_MakeAvailable(spdlog)\n\t\tset(spdlog_FOUND TRUE)\n\tendif()/' torch/CMakeLists.txt
+          sed -i 's/target_link_libraries(${PROJECT_NAME} PUBLIC spdlog::spdlog)/if(spdlog_FOUND)\n\tif(TARGET spdlog::spdlog)\n\t\ttarget_link_libraries(${PROJECT_NAME} PUBLIC spdlog::spdlog)\n\telse()\n\t\ttarget_link_libraries(${PROJECT_NAME} PUBLIC spdlog)\n\tendif()\nendif()/' torch/CMakeLists.txt
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1.2.14
         with:
@@ -225,6 +230,11 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get install gcc g++ git cmake ninja-build lsb-release libsdl2-dev libsdl2-net-dev libpng-dev libsdl2-net-dev libzip-dev zipcmp zipmerge ziptool nlohmann-json3-dev libtinyxml2-dev libboost-dev libopengl-dev libogg-dev libvorbis-dev
+      - name: Fix spdlog issue in torch
+        run: |
+          # Fix spdlog find_package issue in torch CMakeLists.txt
+          sed -i 's/find_package(spdlog REQUIRED)/find_package(spdlog QUIET)\n\tif(NOT spdlog_FOUND)\n\t\tFetchContent_Declare(\n\t\t\tspdlog\n\t\t\tGIT_REPOSITORY https:\/\/github.com\/gabime\/spdlog.git\n\t\t\tGIT_TAG 7e635fca68d014934b4af8a1cf874f63989352b7\n\t\t)\n\t\tFetchContent_MakeAvailable(spdlog)\n\t\tset(spdlog_FOUND TRUE)\n\tendif()/' torch/CMakeLists.txt
+          sed -i 's/target_link_libraries(${PROJECT_NAME} PUBLIC spdlog::spdlog)/if(spdlog_FOUND)\n\tif(TARGET spdlog::spdlog)\n\t\ttarget_link_libraries(${PROJECT_NAME} PUBLIC spdlog::spdlog)\n\telse()\n\t\ttarget_link_libraries(${PROJECT_NAME} PUBLIC spdlog)\n\tendif()\nendif()/' torch/CMakeLists.txt
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1.2.14
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -137,7 +137,8 @@ jobs:
       - name: Update machine
         run: sudo apt update
       - name: Install dependencies
-        run: sudo apt-get install gcc g++ git cmake ninja-build lsb-release libsdl2-dev libsdl2-net-dev libpng-dev libsdl2-net-dev libzip-dev zipcmp zipmerge ziptool nlohmann-json3-dev libtinyxml2-dev libspdlog-dev libboost-dev libopengl-dev libogg-dev libvorbis-dev
+        run: |
+          sudo apt-get install gcc g++ git cmake ninja-build lsb-release libsdl2-dev libsdl2-net-dev libpng-dev libsdl2-net-dev libzip-dev zipcmp zipmerge ziptool nlohmann-json3-dev libtinyxml2-dev libspdlog-dev libboost-dev libopengl-dev libogg-dev libvorbis-dev
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1.2.14
         with:
@@ -222,7 +223,8 @@ jobs:
       - name: Update machine
         run: sudo apt update
       - name: Install dependencies
-        run: sudo apt-get install gcc g++ git cmake ninja-build lsb-release libsdl2-dev libsdl2-net-dev libpng-dev libsdl2-net-dev libzip-dev zipcmp zipmerge ziptool nlohmann-json3-dev libtinyxml2-dev libspdlog-dev libboost-dev libopengl-dev libogg-dev libvorbis-dev
+        run: |
+          sudo apt-get install gcc g++ git cmake ninja-build lsb-release libsdl2-dev libsdl2-net-dev libpng-dev libsdl2-net-dev libzip-dev zipcmp zipmerge ziptool nlohmann-json3-dev libtinyxml2-dev libboost-dev libopengl-dev libogg-dev libvorbis-dev
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1.2.14
         with:


### PR DESCRIPTION
Add `sed` commands to GitHub Actions workflows to resolve `spdlog` compilation errors in `torch/CMakeLists.txt`.

The `torch/CMakeLists.txt` was failing to find `spdlog` as a required package, leading to build failures. This PR modifies the build process to first attempt a quiet `find_package` for `spdlog`, and if not found, it fetches `spdlog` via `FetchContent`. It also adds conditional linking to correctly handle `spdlog::spdlog` or `spdlog` targets, improving build robustness.

---
<a href="https://cursor.com/background-agent?bcId=bc-61908f60-a04f-413a-9894-eaf9c471a352">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-61908f60-a04f-413a-9894-eaf9c471a352">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

